### PR TITLE
Require Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '10'
   - '8'
   - '6'
-  - '4'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=4"
+		"node": ">=6"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -35,7 +35,7 @@
 		"match"
 	],
 	"dependencies": {
-		"builtin-modules": "^2.0.0"
+		"builtin-modules": "^3.0.0"
 	},
 	"devDependencies": {
 		"ava": "*",


### PR DESCRIPTION
This patch updates `builtin-modules` so the list will come from `require('module').builtinModules` interface if it's available.  This is a breaking change only due to dropping node.js 4 but otherwise I believe this improves forward compatibility.