### PR TITLE
Module names that end in a trialing slash should not be considered builtin

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = moduleName => {
 	}
 
 	const slashIndex = moduleName.indexOf('/');
-	if (slashIndex !== -1) {
+	if (slashIndex !== -1 && slashIndex !== moduleName.length - 1) {
 		moduleName = moduleName.slice(0, slashIndex);
 	}
 

--- a/test.js
+++ b/test.js
@@ -4,12 +4,12 @@ import isBuiltinModule from '.';
 test('main', t => {
 	t.true(isBuiltinModule('fs'));
 	t.true(isBuiltinModule('console'));
+	t.true(isBuiltinModule('punycode'));
 
 	t.true(isBuiltinModule('fs/promises'));
 	t.true(isBuiltinModule('assert/strict'));
 
 	// These are actually not, but should not exist
-	t.true(isBuiltinModule('fs/'));
 	t.true(isBuiltinModule('fs/unknown'));
 	t.true(isBuiltinModule('fs/promises/unknown'));
 	t.true(isBuiltinModule('fs/promises?query=1'));
@@ -17,6 +17,7 @@ test('main', t => {
 	t.true(isBuiltinModule('node:fs'));
 	t.true(isBuiltinModule('node:fs/promises'));
 
+	t.false(isBuiltinModule('punycode/'));
 	t.false(isBuiltinModule('unicorn'));
 	t.false(isBuiltinModule('unknown'));
 	t.false(isBuiltinModule('FS'));


### PR DESCRIPTION
Fixes #7 

It is a common practice to differentiate local packages, from builtin packages with the same name, by adding a trailing slash. So a builtin module name with a trailing slash is an explicit signal to the node module loader to NOT use the builtin module.

For example, the punycode module advises users to add a trailing slash to have node load the npm installed module rather than the builtin module. (See https://github.com/mathiasbynens/punycode.js) 

This will fix this upstream bug in rollup. (See https://github.com/rollup/plugins/issues/1211)