### PR TITLE
chore: replace `builtin-modules` dependency with built-in `builtinModules`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import builtinModules from 'builtin-modules';
+import {builtinModules} from 'node:module';
 
 const moduleSet = new Set(builtinModules);
 const NODE_PROTOCOL = 'node:';

--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
 		"check",
 		"match"
 	],
-	"dependencies": {
-		"builtin-modules": "^4.0.0"
-	},
 	"devDependencies": {
 		"ava": "^6.1.2",
 		"tsd": "^0.31.0",


### PR DESCRIPTION
The `builtinModules` array (part of the `node:module` module) was introduced in Node.js version 9.3.0