### PR TITLE
Update `builtin-modules` to v5

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,12 @@
 import builtinModules from 'builtin-modules';
 
-const moduleSet = new Set(builtinModules);
-const NODE_PROTOCOL = 'node:';
-
+let moduleSet;
 export default function isBuiltinModule(moduleName) {
 	if (typeof moduleName !== 'string') {
 		throw new TypeError('Expected a string');
 	}
 
-	if (moduleName.startsWith(NODE_PROTOCOL)) {
-		moduleName = moduleName.slice(NODE_PROTOCOL.length);
-	}
+	moduleSet ??= new Set(builtinModules);
 
 	return moduleSet.has(moduleName);
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"match"
 	],
 	"dependencies": {
-		"builtin-modules": "^4.0.0"
+		"builtin-modules": "^5.0.0"
 	},
 	"devDependencies": {
 		"ava": "^6.1.2",

--- a/test.js
+++ b/test.js
@@ -4,7 +4,8 @@ import isBuiltinModule from './index.js';
 test('main', t => {
 	t.true(isBuiltinModule('fs'));
 	t.true(isBuiltinModule('console'));
-	t.true(isBuiltinModule('punycode'));
+	// Deprecated
+	t.false(isBuiltinModule('punycode'));
 
 	t.true(isBuiltinModule('fs/promises'));
 	t.true(isBuiltinModule('assert/strict'));
@@ -15,6 +16,10 @@ test('main', t => {
 
 	t.true(isBuiltinModule('node:fs'));
 	t.true(isBuiltinModule('node:fs/promises'));
+
+	t.true(isBuiltinModule('node:test'));
+	// Only works with `node:` prefix
+	t.false(isBuiltinModule('test'));
 
 	t.false(isBuiltinModule('punycode/'));
 	t.false(isBuiltinModule('unicorn'));

--- a/test.js
+++ b/test.js
@@ -22,6 +22,7 @@ test('main', t => {
 	t.false(isBuiltinModule('test'));
 
 	t.false(isBuiltinModule('punycode/'));
+	t.false(isBuiltinModule('fs/'));
 	t.false(isBuiltinModule('unicorn'));
 	t.false(isBuiltinModule('unknown'));
 	t.false(isBuiltinModule('FS'));

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ import isBuiltinModule from './index.js';
 test('main', t => {
 	t.true(isBuiltinModule('fs'));
 	t.true(isBuiltinModule('console'));
+
 	// Deprecated
 	t.false(isBuiltinModule('punycode'));
 
@@ -18,6 +19,7 @@ test('main', t => {
 	t.true(isBuiltinModule('node:fs/promises'));
 
 	t.true(isBuiltinModule('node:test'));
+
 	// Only works with `node:` prefix
 	t.false(isBuiltinModule('test'));
 


### PR DESCRIPTION
I assume https://github.com/sindresorhus/builtin-modules/pull/18 will release as v5, this should work after it gets released.

I also changed `moduleSet` to lazy evaluation.